### PR TITLE
FIX: Only hide likes column in category, not in mixed topic list

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -805,8 +805,14 @@ tbody {
 }
 
 // Hide likes column for roadmap
-.category-roadmap {
+body.category-roadmap {
   th.likes, td.likes {
     display: none;
+  }
+}
+
+tr.category-roadmap {
+  td.likes a {
+    visibility: hidden;
   }
 }


### PR DESCRIPTION
This fixes an alignment issue when the topic list has topics from multiple categories, and continues to hide the likes column in the roadmap category

Before:
<img width="1144" alt="screen shot 2018-11-13 at 12 00 41 pm" src="https://user-images.githubusercontent.com/1681963/48430000-4b2b8f00-e73c-11e8-9883-11ea26978494.png">


After: 
<img width="1150" alt="screen shot 2018-11-13 at 12 05 34 pm" src="https://user-images.githubusercontent.com/1681963/48430166-a1003700-e73c-11e8-9142-3397a3a129f1.png">

