### PR TITLE
UX: adjust theme for new btn-transparent classes in Discourse

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -91,10 +91,28 @@ button, // General button styles
     .d-icon {
       color: var(--secondary);
     }
+    &.btn-transparent {
+      color: var(--danger);
+      .d-icon {
+        color: currentColor;
+      }
+    }
     .discourse-no-touch & {
       &:hover {
         background: var(--wyze-darken-danger);
         border-color: var(--wyze-darken-danger);
+      }
+    }
+  }
+
+  &.btn-transparent {
+    border: none;
+
+    .discourse-no-touch & {
+      &:hover {
+        .d-icon {
+          color: currentColor;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes this issue where the delete buttons can be transparent and removes the excessive borders in this menu

![image](https://github.com/wyzelabs/discourse-wyze-theme/assets/1681963/c3f26c0d-de15-4cd0-a484-bb82728faa79)
